### PR TITLE
[Bugfix] Deck generates numbers between max and min

### DIFF
--- a/src/models/Deck.test.ts
+++ b/src/models/Deck.test.ts
@@ -10,6 +10,22 @@ it("returns the cards left to be dealt", () => {
   expect(deck.getCards().length).toEqual(97);
 });
 
+describe("#getCards", () => {
+  it("generates a correct deck", () => {
+    const deck = new Deck(new Card(1), new Card(10));
+    expect(deck.getCards()).toEqual([
+      new Card(2),
+      new Card(3),
+      new Card(4),
+      new Card(5),
+      new Card(6),
+      new Card(7),
+      new Card(8),
+      new Card(9),
+    ]);
+  });
+});
+
 describe("#draw", () => {
   it("draws a random card", () => {
     const deck = new Deck(new Card(1), new Card(100));

--- a/src/models/Deck.ts
+++ b/src/models/Deck.ts
@@ -26,7 +26,12 @@ export class Deck {
   }
 
   private range(start: number, end: number) {
-    return [...Array(end - start - 1).keys()];
+    const arr = [];
+    for (let i = start + 1; i < end; i += 1) {
+      arr.push(i);
+    }
+
+    return arr;
   }
 
   private getRandomNumber() {


### PR DESCRIPTION
The old code was generating cards for `0` and `1` and probably a few other nasty bad things